### PR TITLE
API Client generates invalid signature in case of authorized GET request

### DIFF
--- a/src/coin_check.js
+++ b/src/coin_check.js
@@ -73,16 +73,13 @@ CoinCheck.prototype = {
     _transfer: null,
     _headers: {},
 
-    setSignature: function (path, arr) {
+    setSignature: function (path, obj) {
         var nonce, url, message, signature;
 
         nonce = new Date().getTime();
-        // url = this.apiBase + path;
         url = 'https://' + this.apiBase + path;
-        // message = nonce + url + querystring.stringify(arr);
-        message = nonce + url + JSON.stringify(arr);
+        message = nonce + url + ((Object.keys(obj).length > 0) ? JSON.stringify(obj) : '');
         signature = crypto.createHmac('sha256', this.secretKey).update(message).digest('hex');
-        //console.info(nonce, url, message, signature);
         this._headers = utils.extend(this._headers, {
             'ACCESS-KEY': this.accessKey,
             'ACCESS-NONCE': nonce,


### PR DESCRIPTION
The current implementation of a signature calculation is not considered that it is passed an empty request body. It causes fail in any authorized GET API calls.

認証ありの GET リクエストの場合、API クライアントが誤ったデジタル署名を生成してしまいます。
現在のデジタル署名生成の実装は空のリクエストボディが渡されることを考慮していません。結果として、GET 系で認証が要求されるすべての API コールに失敗してしまうことになります。