### PR TITLE
Don't overwrite global headers when doing DELETE/ POST request

### DIFF
--- a/src/coin_check.js
+++ b/src/coin_check.js
@@ -88,7 +88,7 @@ CoinCheck.prototype = {
 
     },
     request: function (method, path, params) {
-        var paramData, options, req, success, error;
+        var headers, paramData, options, req, success, error;
 
         params = params || {};
         paramData = params.data ? params.data : {};
@@ -100,9 +100,10 @@ CoinCheck.prototype = {
         }
 
         this.setSignature(path, paramData);
-
+        headers = this._headers
+        
         if (method == 'post' || method == 'delete') {
-            this._headers = utils.extend(this._headers, {
+            headers = utils.extend(headers, {
                 'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(JSON.stringify(paramData))
             });
@@ -113,7 +114,7 @@ CoinCheck.prototype = {
             port: 443,
             path: path,
             method: method,
-            headers: this._headers
+            headers: headers
         };
         //console.info(req_params);
 

--- a/src/coin_check.js
+++ b/src/coin_check.js
@@ -100,7 +100,7 @@ CoinCheck.prototype = {
         }
 
         this.setSignature(path, paramData);
-        headers = this._headers
+        headers = JSON.parse(JSON.stringify(this._headers));
         
         if (method == 'post' || method == 'delete') {
             headers = utils.extend(headers, {

--- a/src/coin_check.js
+++ b/src/coin_check.js
@@ -72,15 +72,18 @@ CoinCheck.prototype = {
     /** @var Transfer */
     _transfer: null,
     _headers: {},
+    /* int requests */
+    _requests: 0,
 
-    setSignature: function (path, obj) {
+    setSignature: function (path, obj, headers) {
         var nonce, url, message, signature;
-
-        nonce = new Date().getTime();
+        this._requests++;
+        
+        nonce = new Date().getTime() + this._requests;
         url = 'https://' + this.apiBase + path;
         message = nonce + url + ((Object.keys(obj).length > 0) ? JSON.stringify(obj) : '');
         signature = crypto.createHmac('sha256', this.secretKey).update(message).digest('hex');
-        this._headers = utils.extend(this._headers, {
+        return utils.extend(headers, {
             'ACCESS-KEY': this.accessKey,
             'ACCESS-NONCE': nonce,
             'ACCESS-SIGNATURE': signature
@@ -99,8 +102,8 @@ CoinCheck.prototype = {
             paramData = {};
         }
 
-        this.setSignature(path, paramData);
         headers = JSON.parse(JSON.stringify(this._headers));
+        headers = this.setSignature(path, paramData, headers);
         
         if (method == 'post' || method == 'delete') {
             headers = utils.extend(headers, {


### PR DESCRIPTION
Will create 502 Bad Gateway + timeouts on coincheck api when doing subsequent calls (f.e. create 
trade and afterwards get balance when using same client)

when you do f.e.
```
      client.order.create(params); 
```
and afterwards
```
      client.account.balance(params); // <--- this will hang, and eventually return 502.. because coincheck api (nginx) is waiting for additional content) when sending 'Content-Type': 'application/json', 'Content-Length': 20 on a non post request
```